### PR TITLE
Add Custom Cop for Insecure Hash Algorithm

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,3 @@
-inherit_from: config/default.yml
+inherit_from:
+  - config/default.yml
+  - config/rspec.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # CHANGELOG
 
 ## main (unreleased)
-- WIP
+* Add new cop `InsecureHashAlgorithm`. ([#3](https://github.com/cobalthq/cobalt-rubocop/pull/3))
+  * Possible need to re-generate `.rubocop_todo.yml` when updating.
 
 ## 0.1.0 (2021-02-10)
 * Introduce default rules

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
       zeitwerk (~> 2.3)
     ast (2.4.2)
     concurrent-ruby (1.1.8)
+    diff-lcs (1.4.4)
     i18n (1.8.8)
       concurrent-ruby (~> 1.0)
     minitest (5.14.3)
@@ -28,6 +29,19 @@ GEM
     rainbow (3.0.0)
     regexp_parser (2.0.3)
     rexml (3.2.4)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.1)
     rubocop (1.9.1)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -61,6 +75,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (= 2.2.2)
   cobalt-rubocop!
+  rspec (= 3.10.0)
 
 BUNDLED WITH
    2.2.2

--- a/README.md
+++ b/README.md
@@ -59,6 +59,32 @@ The number of offences can be counted:
 grep "Offense count" .rubocop_todo.yml | awk -F: '{sum+=$2} END {print sum}'
 ```
 
+## Custom Cops
+### InsecureHashAlgorithm
+See [Ruby Docs](https://ruby-doc.org/stdlib-2.7.2/libdoc/openssl/rdoc/OpenSSL/Digest.html) for built in hash functions.
+
+- Default Configuration:
+  ```yml
+  Cobalt/InsecureHashAlgorithm:
+    Allowed:
+      - SHA256
+      - SHA384
+      - SHA512
+  ```
+
+  ```ruby
+  # bad
+  OpenSSL::Digest::MD5.digest('abc')
+  OpenSSL::Digest::SHA1.digest('abc')
+  OpenSSL::HMAC.new('abc', 'sha1')
+
+  # good
+  OpenSSL::Digest::SHA256.digest('abc')
+  OpenSSL::Digest::SHA384.digest('abc')
+  OpenSSL::Digest::SHA512.digest('abc')
+  OpenSSL::HMAC.new('abc', 'sha256')
+  ```
+
 ## Development
 ```shell
 git clone git@github.com:cobalthq/cobalt-rubocop.git

--- a/cobalt-rubocop.gemspec
+++ b/cobalt-rubocop.gemspec
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require_relative 'lib/rubocop/cobalt/version'
+
 Gem::Specification.new do |s|
   s.name = 'cobalt-rubocop'
-  s.version = '0.1.0'
+  s.version = RuboCop::Cobalt::VERSION
   s.authors = 'Cobalt Engineering'
 
   s.summary = 'Cobalt RuboCop'
@@ -15,7 +17,7 @@ Gem::Specification.new do |s|
   s.metadata['source_code_uri'] = s.homepage
   s.metadata['changelog_uri'] = "#{s.homepage}/blob/main/CHANGELOG.md"
 
-  s.files = Dir['README.md', 'LICENSE', 'CHANGELOG.md', 'config/*.yml']
+  s.files = Dir['README.md', 'LICENSE', 'CHANGELOG.md', 'config/*.yml', 'lib/**/*.rb']
   s.required_ruby_version = '>= 2.5.0'
 
   s.add_dependency 'rubocop', '1.9.1'
@@ -24,4 +26,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'rubocop-rspec', '2.2.0'
 
   s.add_development_dependency 'bundler', '2.2.2'
+  s.add_development_dependency 'rspec', '3.10.0'
 end

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,5 +1,6 @@
 require:
   - rubocop-performance
+  - rubocop/cop/cobalt
 
 AllCops:
   NewCops: enable
@@ -57,3 +58,6 @@ Style/IfUnlessModifier:
 
 Style/ClassAndModuleChildren:
   EnforcedStyle: nested
+
+Cobalt/InsecureHashAlgorithm:
+  Enabled: true

--- a/lib/rubocop/cobalt/version.rb
+++ b/lib/rubocop/cobalt/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cobalt
+    VERSION = '0.1.0'
+  end
+end

--- a/lib/rubocop/cop/cobalt.rb
+++ b/lib/rubocop/cop/cobalt.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'rubocop/cop/cobalt/insecure_hash_algorithm'

--- a/lib/rubocop/cop/cobalt/insecure_hash_algorithm.rb
+++ b/lib/rubocop/cop/cobalt/insecure_hash_algorithm.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+# original code from https://github.com/github/rubocop-github/blob/master/lib/rubocop/cop/github/insecure_hash_algorithm.rb
+
+module RuboCop
+  module Cop
+    module Cobalt
+      class InsecureHashAlgorithm < Cop
+        # Matches constants like these:
+        #   Digest::MD5
+        #   OpenSSL::Digest::MD5
+        def_node_matcher :insecure_const?, <<-PATTERN
+          (const (const _ :Digest) #insecure_algorithm?)
+        PATTERN
+
+        # Matches calls like these:
+        #   Digest.new('md5')
+        #   Digest.hexdigest('md5', 'str')
+        #   OpenSSL::Digest.new('md5')
+        #   OpenSSL::Digest.hexdigest('md5', 'str')
+        #   OpenSSL::Digest::Digest.new('md5')
+        #   OpenSSL::Digest::Digest.hexdigest('md5', 'str')
+        #   OpenSSL::Digest::Digest.new(:MD5)
+        #   OpenSSL::Digest::Digest.hexdigest(:MD5, 'str')
+        def_node_matcher :insecure_digest?, <<-PATTERN
+          (send
+            (const _ {:Digest :HMAC})
+            #not_just_encoding?
+            #insecure_algorithm?
+            ...)
+        PATTERN
+
+        # Matches calls like "Digest(:MD5)".
+        def_node_matcher :insecure_hash_lookup?, <<-PATTERN
+          (send _ :Digest #insecure_algorithm?)
+        PATTERN
+
+        # Matches calls like "OpenSSL::HMAC.new(secret, hash)"
+        def_node_matcher :openssl_hmac_new?, <<-PATTERN
+          (send (const (const _ :OpenSSL) :HMAC) :new ...)
+        PATTERN
+
+        # Matches calls like "OpenSSL::HMAC.new(secret, 'sha1')"
+        def_node_matcher :openssl_hmac_new_insecure?, <<-PATTERN
+          (send (const (const _ :OpenSSL) :HMAC) :new _ #insecure_algorithm?)
+        PATTERN
+
+        # Matches Rails's Digest::UUID.
+        def_node_matcher :digest_uuid?, <<-PATTERN
+          (const (const _ :Digest) :UUID)
+        PATTERN
+
+        def_node_matcher :uuid_v3?, <<-PATTERN
+          (send (const _ :UUID) :uuid_v3 ...)
+        PATTERN
+
+        def_node_matcher :uuid_v5?, <<-PATTERN
+          (send (const _ :UUID) :uuid_v5 ...)
+        PATTERN
+
+        def insecure_algorithm?(val)
+          return false if val == :Digest # Don't match "Digest::Digest".
+
+          case alg_name(val)
+          when *allowed_hash_functions, Symbol
+            false
+          else
+            true
+          end
+        end
+
+        def not_just_encoding?(val)
+          !just_encoding?(val)
+        end
+
+        def just_encoding?(val)
+          %i[hexencode bubblebabble].include?(val)
+        end
+
+        DEFAULT_ALLOWED = %w[
+          SHA256
+          SHA384
+          SHA512
+        ].freeze
+
+        def allowed_hash_functions
+          @allowed_hash_functions ||= cop_config.fetch('Allowed', DEFAULT_ALLOWED).map(&:downcase)
+        end
+
+        def alg_name(val)
+          return :nil if val.nil?
+          return val.to_s.downcase unless val.is_a?(RuboCop::AST::Node)
+
+          case val.type
+          when :sym, :str
+            val.children.first.to_s.downcase
+          else
+            val.type
+          end
+        end
+
+        def on_const(const_node)
+          add_offense(const_node, message: default_message) if insecure_const?(const_node) && !digest_uuid?(const_node)
+        end
+
+        def on_send(send_node)
+          if uuid_v3?(send_node) && !allowed_hash_functions.include?('md5')
+            add_offense(send_node, message: "uuid_v3 uses MD5, which is not allowed. Prefer: #{allowed_hash_functions.join(', ')}")
+          elsif uuid_v5?(send_node) && !allowed_hash_functions.include?('sha1')
+            add_offense(send_node, message: "uuid_v5 uses SHA1, which is not allowed. Prefer: #{allowed_hash_functions.join(', ')}")
+          elsif openssl_hmac_new?(send_node) && openssl_hmac_new_insecure?(send_node) ||
+              insecure_digest?(send_node) || insecure_hash_lookup?(send_node)
+            add_offense(send_node, message: default_message)
+          end
+        end
+
+        def default_message
+          "This hash function is not allowed. Prefer: #{allowed_hash_functions.join(', ')}"
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/rubocop/cobalt_spec.rb
+++ b/spec/lib/rubocop/cobalt_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cobalt do
+  it 'has a version number' do
+    expect(described_class::VERSION).not_to be nil
+  end
+end

--- a/spec/lib/rubocop/cop/cobalt/insecure_hash_algorithm_spec.rb
+++ b/spec/lib/rubocop/cop/cobalt/insecure_hash_algorithm_spec.rb
@@ -1,0 +1,416 @@
+# frozen_string_literal: true
+
+# converted from https://github.com/github/rubocop-github/blob/master/test/test_insecure_hash_algorithm.rb
+
+RSpec.describe RuboCop::Cop::Cobalt::InsecureHashAlgorithm, :config do
+  context 'when benign apis' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          def hexencode_the_string_md5
+            Digest.hexencode('anything')
+          end
+          def bubblebabble_the_string_md5
+            Digest.bubblebabble('anything')
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when indirect openssl hmac sh256' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          HASH = OpenSSL::Digest::SHA256
+          attr :secret
+          def secret_hmac
+            OpenSSL::HMAC.new(self.secret, HASH)
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when openssl sh1' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Foo
+          attr :secret
+          def secret_hmac
+            OpenSSL::HMAC.new(self.secret, 'sha1')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class.new.default_message}
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when digest method md5 string' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def h
+            Digest('md5')
+            ^^^^^^^^^^^^^ #{described_class.new.default_message}
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when digest method md5 symbol' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def h
+            Digest(:MD5)
+            ^^^^^^^^^^^^ #{described_class.new.default_message}
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when digest method sha256 string' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          def h
+            Digest('sha256')
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when digest method sha256 symbol' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          def h
+            Digest(:SHA256)
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when digest md5' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Foo
+          HASH = Digest::MD5
+                 ^^^^^^^^^^^ #{described_class.new.default_message}
+        end
+      RUBY
+    end
+  end
+
+  context 'when openssl digest md5' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Foo
+          HASH = OpenSSL::Digest::MD5
+                 ^^^^^^^^^^^^^^^^^^^^ #{described_class.new.default_message}
+        end
+      RUBY
+    end
+  end
+
+  context 'when digest sha1' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Foo
+          HASH = Digest::SHA1
+                 ^^^^^^^^^^^^ #{described_class.new.default_message}
+        end
+      RUBY
+    end
+  end
+
+  context 'when openssl digest sha1' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Foo
+          HASH = OpenSSL::Digest::SHA1
+                 ^^^^^^^^^^^^^^^^^^^^^ #{described_class.new.default_message}
+        end
+      RUBY
+    end
+  end
+
+  context 'when digest sha256' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          HASH = Digest::SHA256
+        end
+      RUBY
+    end
+  end
+
+  context 'when openssl digest sha256' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          HASH = OpenSSL::Digest::SHA256
+        end
+      RUBY
+    end
+  end
+
+  context 'when hexdigest on random class' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          def something(str)
+            HASH.hexdigest(str)
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when md5 hexdigest' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def something(str)
+            Digest::MD5.hexdigest(str)
+            ^^^^^^^^^^^ #{described_class.new.default_message}
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when openssl md5 hexdigest' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def something(str)
+            OpenSSL::Digest::MD5.hexdigest(str)
+            ^^^^^^^^^^^^^^^^^^^^ #{described_class.new.default_message}
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when openssl md5 digest by name' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def something(str)
+            OpenSSL::Digest.digest('MD5', str)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class.new.default_message}
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when openssl sha1 digest by name' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def something(str)
+            OpenSSL::Digest.digest('SHA1', str)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class.new.default_message}
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when openssl sha1 digest by name mixed case' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def something(str)
+            OpenSSL::Digest.digest('Sha1', str)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class.new.default_message}
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when openssl sha256 disgest by name' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          def bar(str)
+            OpenSSL::Digest.digest('SHA256', str)
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when openssl md5 hmac by name' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def bar(str)
+            OpenSSL::HMAC.hexdigest('md5', str)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class.new.default_message}
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when openssl sha1 hmac by name' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def bar(str)
+            OpenSSL::HMAC.hexdigest('sha1', str)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class.new.default_message}
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when openssl sha256 hmac by name' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          def bar(str)
+            OpenSSL::HMAC.hexdigest('sha256', str)
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when openssl md5 digest instance by name' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def bar
+            OpenSSL::Digest::Digest.new('md5')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class.new.default_message}
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when openssl sha1 digest instance by name' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def bar
+            OpenSSL::Digest::Digest.new('sha1')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{described_class.new.default_message}
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when openssl sha256 digest instance by name' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          def bar
+            OpenSSL::Digest::Digest.new('sha256')
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when uuid from hash' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          def bar
+            Digest::UUID.uuid_from_hash(Digest::SHA256, 'abc', 'def')
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when uuid_v3' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def bar
+            Digest::UUID.uuid_v3('anything', 'anything')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ uuid_v3 uses MD5, which is not allowed. Prefer: sha256, sha384, sha512
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when uuid_v3 with md5 allowed' do
+    let(:cop_config) { {'Allowed' => %w[MD5]} }
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          def bar
+            Digest::UUID.uuid_v3('anything', 'anything')
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when uuid_v4' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          def bar
+            Digest::UUID.uuid_v4
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when uuid_v5' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Foo
+          def bar
+            Digest::UUID.uuid_v5('anything', 'anything')
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ uuid_v5 uses SHA1, which is not allowed. Prefer: sha256, sha384, sha512
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when only sha512 allowed' do
+    let(:cop_config) { {'Allowed' => %w[SHA512]} }
+
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        class Foo
+          HASH = Digest::SHA256
+                 ^^^^^^^^^^^^^^ This hash function is not allowed. Prefer: sha512
+        end
+      RUBY
+    end
+  end
+
+  context 'when multiple hashes allowed' do
+    let(:cop_config) { {'Allowed' => %w[SHA1 SHA256 SHA384 SHA512]} }
+
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        class Foo
+          HASH = Digest::SHA1
+        end
+      RUBY
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+require 'rubocop/rspec/support'
+require 'rubocop/cop/cobalt'
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+    expectations.syntax = :expect
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+    mocks.syntax = :expect
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.warnings = true
+
+  # https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/rspec/expect_offense.rb
+  config.include RuboCop::RSpec::ExpectOffense
+end


### PR DESCRIPTION
- Added Version to match general convention. I believe I need to change the `README` to use `rake release` instead of `gem push` as well.
- Added cop copied from github https://github.com/github/rubocop-github/blob/master/lib/rubocop/cop/github/insecure_hash_algorithm.rb 😄 