### PR TITLE
Avoid warnings on RSpec lets with parameter arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## main (unreleased)
+* Avoid warnings on RSpec `let` with parameter arrays ([#5](https://github.com/cobalthq/cobalt-rubocop/pull/5))
 * Add new cop `InsecureHashAlgorithm`. ([#3](https://github.com/cobalthq/cobalt-rubocop/pull/3))
   * Possible need to re-generate `.rubocop_todo.yml` when updating.
 

--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -14,7 +14,7 @@ RSpec/MessageSpies:
 RSpec/VariableName:
   IgnoredPatterns:
     - ^Authorization
-    - '\[\]$' # For array parameters in rswag `let(:'<parameter_name>[]')` is necessary
+    - '\[\]$' # For array parameters in rswag like `let(:'<parameter_name>[]')`
 
 RSpec/MultipleMemoizedHelpers:
   Max: 17

--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -14,6 +14,7 @@ RSpec/MessageSpies:
 RSpec/VariableName:
   IgnoredPatterns:
     - ^Authorization
+    - '\[\]$' # For array parameters in rswag `let(:'<parameter_name>[]')` is necessary
 
 RSpec/MultipleMemoizedHelpers:
   Max: 17


### PR DESCRIPTION
I had to add a similar `let` to this one, so I thought it could sense to ignore it globally.
https://github.com/cobalthq/cobalt-pentest-api/blob/64ed8af1d09c164d5682a976c4d03c1bb047e34a/spec/api/v2/pentests/collaborators_spec.rb#L85-L86