### PR TITLE
Bump rack to 2.2.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
     parallel (1.21.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rainbow (3.1.1)
     regexp_parser (2.2.0)
     rexml (3.2.5)


### PR DESCRIPTION
* fixes CVE-2022-30123
* fixes CVE-2022-30122