### PR TITLE
Add MFA requirement for RubyGem privileges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 ## main (unreleased)
-* WIP
+* Security: Require Multi-Factor Authentication for RubyGems privileged operations ([#16](https://github.com/cobalthq/cobalt-rubocop/pull/10))
 
 ## 0.5.0 (2022-01-25)
 * Update Gem versions ([#8](https://github.com/cobalthq/cobalt-rubocop/pull/8))

--- a/cobalt-rubocop.gemspec
+++ b/cobalt-rubocop.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.metadata['homepage_uri'] = s.homepage
   s.metadata['source_code_uri'] = s.homepage
   s.metadata['changelog_uri'] = "#{s.homepage}/blob/main/CHANGELOG.md"
+  s.metadata['rubygems_mfa_required'] = 'true'
 
   s.files = Dir['README.md', 'LICENSE', 'CHANGELOG.md', 'config/*.yml', 'lib/**/*.rb']
   s.required_ruby_version = '>= 2.5.0'


### PR DESCRIPTION
- Adds MFA requirement to our gem specification for our gem [owners](https://rubygems.org/gems/cobalt-rubocop)