### PR TITLE
Update Gem versions, remove bundler from gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 ## main (unreleased)
-* Security: Require Multi-Factor Authentication for RubyGems privileged operations ([#16](https://github.com/cobalthq/cobalt-rubocop/pull/10))
+* Update Gem versions: ([#11](https://github.com/cobalthq/cobalt-rubocop/pull/11))
+* Security: Require Multi-Factor Authentication for RubyGems privileged operations ([#10](https://github.com/cobalthq/cobalt-rubocop/pull/10))
 
 ## 0.5.0 (2022-01-25)
 * Update Gem versions ([#8](https://github.com/cobalthq/cobalt-rubocop/pull/8))

--- a/README.md
+++ b/README.md
@@ -88,8 +88,7 @@ See [Ruby Docs](https://ruby-doc.org/stdlib-2.7.2/libdoc/openssl/rdoc/OpenSSL/Di
 ## Development
 ```shell
 git clone git@github.com:cobalthq/cobalt-rubocop.git
-gem install bundler:2.2.16
-bundle _2.2.16_
+bundle install
 ```
 
 ### Testing locally

--- a/cobalt-rubocop.gemspec
+++ b/cobalt-rubocop.gemspec
@@ -21,11 +21,10 @@ Gem::Specification.new do |s|
   s.files = Dir['README.md', 'LICENSE', 'CHANGELOG.md', 'config/*.yml', 'lib/**/*.rb']
   s.required_ruby_version = '>= 2.5.0'
 
-  s.add_dependency 'rubocop', '1.25.0'
-  s.add_dependency 'rubocop-performance', '1.13.2'
-  s.add_dependency 'rubocop-rails', '2.13.2'
-  s.add_dependency 'rubocop-rspec', '2.8.0'
+  s.add_dependency 'rubocop', '1.30.1'
+  s.add_dependency 'rubocop-performance', '1.14.2'
+  s.add_dependency 'rubocop-rails', '2.15.0'
+  s.add_dependency 'rubocop-rspec', '2.11.1'
 
-  s.add_development_dependency 'bundler', '2.2.16'
   s.add_development_dependency 'rspec', '3.10.0'
 end


### PR DESCRIPTION
- Update Gem versions
- Removed bundler steps as that is no longer necessary from the changes implemented in https://github.com/cobalthq/cobalt-rubocop/pull/9