### PR TITLE
[PX-3409] Relax depdendency versions and bump to 0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 ## main (unreleased)
-* WIP
+
+## 0.8.0 (2023-04-04)
+* Relax dependency versions
 
 ## 0.7.0 (2022-08-24)
 * Update Gem versions: ([#12](https://github.com/cobalthq/cobalt-rubocop/pull/12))

--- a/cobalt-rubocop.gemspec
+++ b/cobalt-rubocop.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |s|
   s.files = Dir['README.md', 'LICENSE', 'CHANGELOG.md', 'config/*.yml', 'lib/**/*.rb']
   s.required_ruby_version = '>= 2.5.0'
 
-  s.add_dependency 'rubocop', '1.35.1'
-  s.add_dependency 'rubocop-performance', '1.14.3'
-  s.add_dependency 'rubocop-rails', '2.15.2'
-  s.add_dependency 'rubocop-rspec', '2.12.1'
+  s.add_dependency 'rubocop', '~> 1.30'
+  s.add_dependency 'rubocop-performance', '~> 1.14'
+  s.add_dependency 'rubocop-rails', '~> 2.15'
+  s.add_dependency 'rubocop-rspec', '~> 2.11'
 
-  s.add_development_dependency 'rspec', '3.11.0'
+  s.add_development_dependency 'rspec', '~> 3.10'
 end

--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -12,7 +12,7 @@ RSpec/MessageSpies:
   EnforcedStyle: receive
 
 RSpec/VariableName:
-  IgnoredPatterns:
+  AllowedPatterns:
     - ^Authorization
     - '\[\]$' # For array parameters in rswag like `let(:'<parameter_name>[]')`
 

--- a/lib/rubocop/cobalt/version.rb
+++ b/lib/rubocop/cobalt/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Cobalt
-    VERSION = '0.7.0'
+    VERSION = '0.8.0'
   end
 end


### PR DESCRIPTION
In general it's better to not lock versions in gems. This allows the service using it updating rubocop without the need to change cobalt-rubocop.