### PR TITLE
[STAFFENG-121] Maintenance update

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
 inherit_from:
   - config/default.yml
   - config/rspec.yml
+
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,68 @@
 # CHANGELOG
+
 ## main (unreleased)
 
+## 1.0.0 (2023-06-09)
+
+* Bump required ruby version to 3.2.x
+* Add default settings:
+
+```yaml
+RSpec/IndexedLet:
+  Enabled: false
+
+RSpec/Rails/InferredSpecType:
+  Enabled: false
+
+Style/RedundantConstantBase:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+```
+
 ## 0.9.0 (2023-04-20)
+
 * Allow either hash syntax (legacy vs 3.1) as long as the use is consistent.
 
 ## 0.8.0 (2023-04-04)
+
 * Relax dependency versions
 
 ## 0.7.0 (2022-08-24)
+
 * Update Gem versions: ([#12](https://github.com/cobalthq/cobalt-rubocop/pull/12))
 
 ## 0.6.0 (2022-06-24)
+
 * Update Gem versions: ([#11](https://github.com/cobalthq/cobalt-rubocop/pull/11))
 * Security: Require Multi-Factor Authentication for RubyGems privileged operations ([#10](https://github.com/cobalthq/cobalt-rubocop/pull/10))
 
 ## 0.5.0 (2022-01-25)
+
 * Update Gem versions ([#8](https://github.com/cobalthq/cobalt-rubocop/pull/8))
 
 ## 0.4.0 (2021-09-07)
+
 * Update Gem versions ([#7](https://github.com/cobalthq/cobalt-rubocop/pull/7))
 
 ## 0.3.0 (2021-04-16)
+
 * Update Rubocop and Rubocop Performance versions ([#6](https://github.com/cobalthq/cobalt-rubocop/pull/6))
 
 ## 0.2.0 (2021-04-14)
+
 * Avoid warnings on RSpec `let` with parameter arrays ([#5](https://github.com/cobalthq/cobalt-rubocop/pull/5))
 * Add new cop `InsecureHashAlgorithm`. ([#3](https://github.com/cobalthq/cobalt-rubocop/pull/3))
 
 ## 0.1.0 (2021-02-10)
+
 * Introduce default rules
 * Introduce rails rules
 * Introduce rspec rules

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Cobalt RuboCop
+
 [![Gem Version](https://badge.fury.io/rb/cobalt-rubocop.svg)](https://badge.fury.io/rb/cobalt-rubocop)
 [![GitHub License](https://img.shields.io/github/license/cobalthq/cobalt-rubocop.svg)](https://github.com/cobalthq/cobalt-rubocop/blob/main/LICENSE)
 ![Gem Downloads](https://img.shields.io/gem/dt/cobalt-rubocop)
@@ -9,29 +10,35 @@ This repository provides recommended linting rules for Ruby repositories.
 ## Installation
 
 ### Gemfile
+
 #### Add
-  ```ruby
-  group :development do
-    gem 'cobalt-rubocop', require: false
-  end
-  ```
+
+```ruby
+group :development do
+  gem 'cobalt-rubocop', require: false
+end
+```
 
 #### Remove
-  ```ruby
-  gem 'rubocop', require: false
-  gem 'rubocop-performance', require: false
-  gem 'rubocop-rails', require: false
-  gem 'rubocop-rspec', require: false
-  ```
 
-  [Specific versions](https://github.com/cobalthq/cobalt-rubocop/blob/main/cobalt-rubocop.gemspec) installed for:
-  - [rubocop](https://github.com/rubocop-hq/rubocop)
-  - [rubocop-performance](https://github.com/rubocop/rubocop-performance)
-  - [rubocop-rails](https://github.com/rubocop/rubocop-rails)
-  - [rubocop-rspec](https://github.com/rubocop/rubocop-rspec)
+```ruby
+gem 'rubocop', require: false
+gem 'rubocop-performance', require: false
+gem 'rubocop-rails', require: false
+gem 'rubocop-rspec', require: false
+```
+
+[Specific versions](https://github.com/cobalthq/cobalt-rubocop/blob/main/cobalt-rubocop.gemspec) installed for:
+
+- [rubocop](https://github.com/rubocop-hq/rubocop)
+- [rubocop-performance](https://github.com/rubocop/rubocop-performance)
+- [rubocop-rails](https://github.com/rubocop/rubocop-rails)
+- [rubocop-rspec](https://github.com/rubocop/rubocop-rspec)
 
 ### .rubocop.yml
+
 Configuration Options:
+
 ```yaml
 inherit_gem:
   cobalt-rubocop:
@@ -60,10 +67,13 @@ grep "Offense count" .rubocop_todo.yml | awk -F: '{sum+=$2} END {print sum}'
 ```
 
 ## Custom Cops
+
 ### InsecureHashAlgorithm
+
 See [Ruby Docs](https://ruby-doc.org/stdlib-2.7.2/libdoc/openssl/rdoc/OpenSSL/Digest.html) for built in hash functions.
 
 - Default Configuration:
+
   ```yml
   Cobalt/InsecureHashAlgorithm:
     Allowed:
@@ -86,24 +96,30 @@ See [Ruby Docs](https://ruby-doc.org/stdlib-2.7.2/libdoc/openssl/rdoc/OpenSSL/Di
   ```
 
 ## Development
+
 ```shell
 git clone git@github.com:cobalthq/cobalt-rubocop.git
 bundle install
 ```
 
 ### Testing locally
+
 In your application, use the `path` attribute to point to your local copy of the gem
+
 ```ruby
   # Use the relative path from your application, to the cobalt-rubocop folder
   gem 'cobalt-rubocop', path: '../cobalt-rubocop', require: false
 ```
 
 Alternatively:
+
 - `rake build`
 - `gem install pkg/cobalt-rubocop-<version_number>.gem`
 
 ## Publish (internal)
+
 > Note: Publishing a new version of this gem is only meant for maintainers.
+
 - Ensure you have access to publish on [rubygems](https://rubygems.org/gems/cobalt-rubocop).
 - Update [CHANGELOG](https://github.com/cobalthq/cobalt-rubocop/blob/main/CHANGELOG.md).
 - Update [`VERSION`](https://github.com/cobalthq/cobalt-rubocop/blob/main/lib/rubocop/cobalt/version.rb).

--- a/cobalt-rubocop.gemspec
+++ b/cobalt-rubocop.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.metadata['rubygems_mfa_required'] = 'true'
 
   s.files = Dir['README.md', 'LICENSE', 'CHANGELOG.md', 'config/*.yml', 'lib/**/*.rb']
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 3.2.0'
 
   s.add_dependency 'rubocop', '~> 1.30'
   s.add_dependency 'rubocop-performance', '~> 1.14'

--- a/config/default.yml
+++ b/config/default.yml
@@ -67,3 +67,12 @@ Style/MutableConstant:
 
 Style/RedundantConstantBase:
   Enabled: false
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: consistent_comma

--- a/config/default.yml
+++ b/config/default.yml
@@ -5,8 +5,8 @@ require:
 AllCops:
   NewCops: enable
 
-Naming/MethodName:
-  EnforcedStyle: snake_case
+Cobalt/InsecureHashAlgorithm:
+  Enabled: true
 
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation
@@ -17,11 +17,11 @@ Layout/DotPosition:
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
 Layout/LineLength:
   Enabled: false
-
-Layout/ParameterAlignment:
-  EnforcedStyle: with_fixed_indentation
 
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space
@@ -32,14 +32,17 @@ Layout/MultilineOperationIndentation:
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 
-Layout/FirstHashElementIndentation:
-  EnforcedStyle: consistent
+Layout/ParameterAlignment:
+  EnforcedStyle: with_fixed_indentation
+
+Metrics/AbcSize:
+  Enabled: false
 
 Metrics/MethodLength:
   Max: 20
 
-Metrics/AbcSize:
-  Enabled: false
+Naming/MethodName:
+  EnforcedStyle: snake_case
 
 Style/ClassAndModuleChildren:
   EnforcedStyle: nested
@@ -59,8 +62,8 @@ Style/HashSyntax:
 Style/IfUnlessModifier:
   Enabled: false
 
-Cobalt/InsecureHashAlgorithm:
-  Enabled: true
-
 Style/MutableConstant:
+  Enabled: false
+
+Style/RedundantConstantBase:
   Enabled: false

--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -12,7 +12,7 @@ RSpec/MessageSpies:
   EnforcedStyle: receive
 
 RSpec/VariableName:
-  AllowedPatterns:
+  IgnoredPatterns:
     - ^Authorization
     - '\[\]$' # For array parameters in rswag like `let(:'<parameter_name>[]')`
 

--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -8,13 +8,14 @@ Metrics/BlockLength:
 RSpec/ExampleLength:
   Enabled: false
 
+RSpec/IndexedLet:
+  Enabled: false
+
+RSpec/Rails/InferredSpecType:
+  Enabled: false
+
 RSpec/MessageSpies:
   EnforcedStyle: receive
-
-RSpec/VariableName:
-  AllowedPatterns:
-    - ^Authorization
-    - '\[\]$' # For array parameters in rswag like `let(:'<parameter_name>[]')`
 
 RSpec/MultipleMemoizedHelpers:
   Max: 17
@@ -24,3 +25,8 @@ RSpec/NamedSubject:
 
 RSpec/NestedGroups:
   Max: 5
+
+RSpec/VariableName:
+  AllowedPatterns:
+    - ^Authorization
+    - '\[\]$' # For array parameters in rswag like `let(:'<parameter_name>[]')`

--- a/config/rspec.yml
+++ b/config/rspec.yml
@@ -12,7 +12,7 @@ RSpec/MessageSpies:
   EnforcedStyle: receive
 
 RSpec/VariableName:
-  IgnoredPatterns:
+  AllowedPatterns:
     - ^Authorization
     - '\[\]$' # For array parameters in rswag like `let(:'<parameter_name>[]')`
 

--- a/lib/rubocop/cobalt/version.rb
+++ b/lib/rubocop/cobalt/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Cobalt
-    VERSION = '0.9.0'
+    VERSION = '1.0.0'
   end
 end

--- a/lib/rubocop/cop/cobalt/insecure_hash_algorithm.rb
+++ b/lib/rubocop/cop/cobalt/insecure_hash_algorithm.rb
@@ -103,16 +103,18 @@ module RuboCop
           add_offense(const_node, message: default_message) if insecure_const?(const_node) && !digest_uuid?(const_node)
         end
 
+        # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def on_send(send_node)
           if uuid_v3?(send_node) && !allowed_hash_functions.include?('md5')
             add_offense(send_node, message: "uuid_v3 uses MD5, which is not allowed. Prefer: #{allowed_hash_functions.join(', ')}")
           elsif uuid_v5?(send_node) && !allowed_hash_functions.include?('sha1')
             add_offense(send_node, message: "uuid_v5 uses SHA1, which is not allowed. Prefer: #{allowed_hash_functions.join(', ')}")
-          elsif openssl_hmac_new?(send_node) && openssl_hmac_new_insecure?(send_node) ||
+          elsif (openssl_hmac_new?(send_node) && openssl_hmac_new_insecure?(send_node)) ||
               insecure_digest?(send_node) || insecure_hash_lookup?(send_node)
             add_offense(send_node, message: default_message)
           end
         end
+        # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         def default_message
           "This hash function is not allowed. Prefer: #{allowed_hash_functions.join(', ')}"

--- a/spec/lib/rubocop/cobalt_spec.rb
+++ b/spec/lib/rubocop/cobalt_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe RuboCop::Cobalt do
   it 'has a version number' do
-    expect(described_class::VERSION).not_to be nil
+    expect(described_class::VERSION).not_to be_nil
   end
 end


### PR DESCRIPTION
* Update required ruby version to align with version used
* Bump version to 1.0.0 as ruby required version is sort of a breaking change

New default cops:

```yaml
RSpec/IndexedLet:
  Enabled: false
RSpec/Rails/InferredSpecType:
  Enabled: false
Style/RedundantConstantBase:
  Enabled: false
Style/TrailingCommaInArguments:
  EnforcedStyleForMultiline: consistent_comma
Style/TrailingCommaInArrayLiteral:
  EnforcedStyleForMultiline: consistent_comma
Style/TrailingCommaInHashLiteral:
  EnforcedStyleForMultiline: consistent_comma
```