### PR TITLE
Don't lint code inside vendor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## main (unreleased)
 
+## 1.1.0 (2023-07-06)
+
+* Don't lint code inside `vendor` folders
 * Maintenance:
   * Add CI status checks
   * Add dependabot

--- a/config/default.yml
+++ b/config/default.yml
@@ -6,6 +6,7 @@ AllCops:
   NewCops: enable
   Exclude:
     - '**/vendor/**/*'
+    - 'components/scans/vendor/**/*'
 
 Cobalt/InsecureHashAlgorithm:
   Enabled: true

--- a/config/default.yml
+++ b/config/default.yml
@@ -4,6 +4,8 @@ require:
 
 AllCops:
   NewCops: enable
+  Exclude:
+    - '**/vendor/**/*'
 
 Cobalt/InsecureHashAlgorithm:
   Enabled: true

--- a/lib/rubocop/cobalt/version.rb
+++ b/lib/rubocop/cobalt/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Cobalt
-    VERSION = '1.0.0'
+    VERSION = '1.1.0'
   end
 end


### PR DESCRIPTION
Not linting `vendor` is in theory a default, but I think that by defining `AllCops` we may be overwritting . This also catches `vendor` folder inside components. Background is I want to put generated code in `vendor`, or at least try. Even if it's unused, seems like a good default