### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-* @josh-hamacher-cobalt @sergey-kruk-cobalt @davidgm0
+@josh-hamacher-cobalt @davidgm0 @TaylorBriggs


### PR DESCRIPTION
While reviewing the library ([ref](https://zombie.atlassian.net/wiki/spaces/ENG/pages/2654961665/Library+Checklist+Cobalt+Rubocop+cobalt-rubocop)), we discovered the `CODEOWNERS` need to be updated.