### PR TITLE
[FX-2496] Add deploy gem to github actions

### DIFF
--- a/.github/workflows/deploy-gem.yaml
+++ b/.github/workflows/deploy-gem.yaml
@@ -1,0 +1,32 @@
+name: "Deploy Gem"
+on:
+  push:
+    tags:
+      - "**" # Matches all tags
+    branches:
+      - main # Only main
+jobs:
+  publish:
+    runs-on: ubuntu-latest.
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2
+          bundler-cache: true
+      - name: Gem build
+        run: |
+          gem build cobalt-rubocop.gemspec -o cobalt-rubocop.gem
+      - name: Gem publish
+        run: |
+          touch ~/.gem/credentials
+          echo ":github: Bearer ${{github.token}}" > ~/.gem/credentials
+          chmod 0600 ~/.gem/credentials
+          gem push --key github --host https://rubygems.pkg.github.com/cobalthq cobalt-rubocop.gem


### PR DESCRIPTION
# JIRA: [FX-2496](https://zombie.atlassian.net/browse/FX-2496)

Adds a job to deploy the gem to github packages from the main branch.

I have a [follow-up task](https://zombie.atlassian.net/browse/FX-3917) to update everything using this gem to point at github packages instead of the public rubygems.

[FX-2496]: https://zombie.atlassian.net/browse/FX-2496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ